### PR TITLE
Add and remove link to DOM.

### DIFF
--- a/pdfkitx.client.js
+++ b/pdfkitx.client.js
@@ -7,7 +7,10 @@ PDFDocument.prototype.write = function (filename) {
     var link = document.createElement('a');
     link.href = this.toBlobURL('application/pdf')
     link.download = filename;
-    link.click();
+
+	document.body.appendChild(link); // add element to DOM
+    link.click(); // programmatically click the link
+	document.body.removeChild(link); // remove element from DOM
   });
   this.end();
 }


### PR DESCRIPTION
i tried your simple quick-start example from within an meteor event-handler and it didn't worked. it worked if i added & removed the link from DOM tree. hope this is a suitable fix and i didn't miss something.
